### PR TITLE
chore(refactor): use array.includes()

### DIFF
--- a/lib/edge-config.ts
+++ b/lib/edge-config.ts
@@ -30,7 +30,7 @@ export const isWhitelistedEmail = async (email: string) => {
   } catch (e) {
     whitelistedEmails = [];
   }
-  return new Set(whitelistedEmails).has(email);
+  return whitelistedEmails.includes(email);
 };
 
 export const isBlacklistedEmail = async (email: string) => {
@@ -50,5 +50,5 @@ export const isReservedKey = async (key: string) => {
   } catch (e) {
     reservedKey = [];
   }
-  return new Set(reservedKey).has(key);
+  return reservedKey.includes(key);
 };


### PR DESCRIPTION
No need to initialize the Set (which will already iterate over the array).

The Set would be useful if you were planning to reuse it but not for one time use.

### Set

```js
var arr = Array.from({length: 100_000}).map((_, i) => `item${i}`);
var start = Date.now();
new Set(arr).has('notfound');
var end = Date.now();
console.log(`${end - start}ms`);
```

### Array

```js
var arr = Array.from({length: 100_000}).map((_, i) => `item${i}`);
var start = Date.now();
arr.includes('notfound');
var end = Date.now();
console.log(`${end - start}ms`);
```